### PR TITLE
hotfix: fix return to game mode

### DIFF
--- a/gamescope-session-steam/usr/bin/steamos-desktop-return
+++ b/gamescope-session-steam/usr/bin/steamos-desktop-return
@@ -7,5 +7,11 @@ if [[ "$PATH" =~ nested_plasma ]]; then
 fi
 
 # If not running in a nested desktop, continue with normal script execution
+/usr/bin/steamrestart
 /usr/libexec/os-session-select gamescope
-pkill -U $USER
+if [[ ! -z $(systemctl status gdm | grep running) ]]; then
+        exec gnome-session-quit --no-prompt
+fi
+if [[ ! -z $(systemctl status sddm | grep running) ]]; then
+        exec qdbus org.kde.Shutdown /Shutdown org.kde.Shutdown.logout
+fi


### PR DESCRIPTION
`pkill -U $USER` is much too harsh, and can lead to frequent issues returning to game mode. it also kills services like ssh and sunshine unintentionally.

reverting only this should solve the failure to return to game mode